### PR TITLE
Pin Argo CD component

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,4 +1,7 @@
 parameters:
+  component_versions:
+    argocd:
+      version: 696b4b4cb9a86ebc845daa314a0a98957f89e99b # Before removing deprecated params
   secret_management:
     vault_addr: https://vault.example.com
     vault_mount: kv


### PR DESCRIPTION
To a version before removing the deprecated parameters [1].

[1] https://github.com/projectsyn/component-argocd/pull/8

This should fix the issue observed in https://github.com/projectsyn/component-argocd/pull/8#issuecomment-712902104