### PR TITLE
Move component definitions to `parameters.components`

### DIFF
--- a/commodore.yml
+++ b/commodore.yml
@@ -3,9 +3,3 @@ classes:
   - global.distribution.${facts:distribution}
   - global.cloud.${facts:cloud}
   - ${cluster:tenant}.${cluster:name}
-
-components:
-  - name: argocd
-    url: https://github.com/projectsyn/component-argocd.git
-  - name: metrics-server
-    url: https://github.com/projectsyn/component-metrics-server.git

--- a/params.yml
+++ b/params.yml
@@ -24,3 +24,9 @@ parameters:
 
   steward:
     api_url: http://lieutenant.172-18-0-2.nip.io
+
+  components:
+    argocd:
+      url: https://github.com/projectsyn/component-argocd.git
+    metrics-server:
+      url: https://github.com/projectsyn/component-metrics-server.git


### PR DESCRIPTION
This PR changes the Commodore defaults to be ready for https://github.com/projectsyn/commodore/pull/284