### PR TITLE
Disable argocd monitoring

### DIFF
--- a/params.yml
+++ b/params.yml
@@ -2,6 +2,11 @@ parameters:
   secret_management:
     vault_addr: https://vault.example.com
     vault_role: syn-cluster
+
+  argocd:
+    monitoring:
+      enabled: false
+
   commodore:
     jsonnet_libs:
       - name: kube-libsonnet


### PR DESCRIPTION
When argocd monitoring is enabled and follwing the getting started guide, the sync of the argocd application will fail, as the
cluster is missing certain prometheus CRDs.
