### PR TITLE
Remove deprecated `commodore.jsonnet_libs`

### DIFF
--- a/params.yml
+++ b/params.yml
@@ -7,14 +7,6 @@ parameters:
     monitoring:
       enabled: false
 
-  commodore:
-    jsonnet_libs:
-      - name: kube-libsonnet
-        repository: https://github.com/bitnami-labs/kube-libsonnet
-        files:
-          - libfile: kube.libsonnet
-            targetfile: kube.libjsonnet
-
   kapitan:
     vars:
       namespace: cluster


### PR DESCRIPTION
This configuration has been deprecated since Commodore [v0.6.0].

[v0.6.0]: https://syn.tools/commodore/reference/deprecation-notices.html#_v0_6_0