### PR TITLE
Add contribution guide with release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# How to contribute
+
+This code repository is part of Project Syn and the contribution guide at
+https://syn.tools/syn/about/contribution_guide.html does apply.
+
+Submit Pull Requests at https://github.com/projectsyn/getting-started-commodore-defaults/pulls.
+
+## Releasing
+
+This repo should be tagged with the matching [Commodore version](https://github.com/projectsyn/commodore/releases). The [Getting Started Guide](https://syn.tools/syn/tutorials/getting-started.html) should be updated with the newly released version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,4 +7,7 @@ Submit Pull Requests at https://github.com/projectsyn/getting-started-commodore-
 
 ## Releasing
 
-This repo should be tagged with the matching [Commodore version](https://github.com/projectsyn/commodore/releases). The [Getting Started Guide](https://syn.tools/syn/tutorials/getting-started.html) should be updated with the newly released version.
+Tags in this repository should be used to specify the [Commodore version](https://github.com/projectsyn/commodore/releases) with which the configuration has been written/tested.
+The tags are used in the [Getting Started Guide](https://syn.tools/syn/tutorials/getting-started.html) to ensure a matching Commodore version and default configuration are used.
+
+When updating this repository, you should check if the  [Getting Started Guide](https://syn.tools/syn/tutorials/getting-started.html) needs to be updated as well.


### PR DESCRIPTION
Add default `CONTRIBUTING.md ` with release guide as discussed in chat.